### PR TITLE
the property is called "tls" not "ssl"

### DIFF
--- a/src/plugins/tls.md
+++ b/src/plugins/tls.md
@@ -51,7 +51,7 @@ As specified on the [Server](../configuration/server.md) configuration section, 
 
 ```Python
 [SERVER]
-    Listen 443 ssl
+    Listen 443 tls
 ```
 
 With that setup, we have instructed that the Listener on TCP port 443 will use our TLS plugin that provides _ssl_ capabilities.


### PR DESCRIPTION
I believe the docs are out of date with the code.  [Here](https://github.com/monkey/monkey/blob/master/mk_server/mk_config.c#L247) the code is looking for a property called "tls" but the docs call it "ssl"