### PR TITLE
Fix link to SSL docs.

### DIFF
--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -12,4 +12,4 @@ Plugins are shared library loaded on startup once the Server reads the content o
  * [Log Writer](log_writer.md)
  * [Liana: plain sockets transport](liana.md)
  * [Mandril Security](mandril_security.md)
- * [Secure Socket Layer (SSL/HTTPS)](polarssl.md)
+ * [Secure Socket Layer (SSL/HTTPS)](tls.md)


### PR DESCRIPTION
It was pointing to the old file - polar - but should point to the new tls.md file.